### PR TITLE
Hotfix: TADS "name" field empty

### DIFF
--- a/src/codegen/tads/tads.handlebars
+++ b/src/codegen/tads/tads.handlebars
@@ -4,7 +4,7 @@
 #include <en_us.h>
 
 versionInfo: GameID
-  name = '{{{map.name}}}'
+  name = '{{{map.title}}}'
   byline = 'by {{{map.author}}}'
   version = '1.0'
   desc = '"{{{map.description}}}'


### PR DESCRIPTION
While the field inside a ``.t3`` source file is indeed dubbed **name**, the correct handlebar variable this corresponds to is **map.title**.