### PR TITLE
Hotfix: Polluted Window control state

### DIFF
--- a/src/controls/window.ts
+++ b/src/controls/window.ts
@@ -11,6 +11,9 @@ export class Window {
     this.elem.querySelector('.ok').addEventListener('click', () => {
       this.close();
       if(onOK instanceof Function) onOK();
+
+      onCancel = null;
+      onOK = null;
     });
 
     let cancel: HTMLElement = this.elem.querySelector('.cancel');
@@ -18,6 +21,9 @@ export class Window {
     this.elem.querySelector('.cancel').addEventListener('click', () => {
       this.close();
       if(onCancel instanceof Function) onCancel();
+
+      onCancel = null;
+      onOK = null;
     });
     
     this.open();


### PR DESCRIPTION
When closing a [``Window``](https://github.com/henck/trizbort/blob/master/src/controls/window.ts) control, the ``onOK`` and ``onCancel`` state are actually never reset, resulting in undesirable side-effects.

Test scenario: 

* Open a **"New Map"** dialog, 
* Cancel dialog.
* Navigate to **"Render Settings"**.
* Change to **Obsidian** theme.
* Confirm by clicking **"OK"**

Result: While the theme is changed to the Obsidian color scheme, any previous map progress is also deleted.

Expected result: The theme is switched to Obsidian, the map contents are retained.

This PR resolves this issue by setting the ``onOK`` and ``onCancel`` properties to ``null`` upon closing a dialog.

Technical note: Evidently, the superior solution would be to re-implement the ``Window`` control
as a singleton. Alas, I had some trouble getting this to work properly during my initial
tests.