### PR TITLE
Hotfix: Repeated map import fails

### DIFF
--- a/src/panels/menuPanel/menuPanel.ts
+++ b/src/panels/menuPanel/menuPanel.ts
@@ -41,8 +41,18 @@ export class MenuPanel extends Panel {
     this.createMenuItem('#menu-export-quest', () => { this.actionGenerateCode(new QuestGenerator(App.map), 'aslx'); });
     this.createMenuItem('#menu-export-textadventurejs', () => { this.actionGenerateCode(new TextadventurejsGenerator(App.map), 'txt'); });
 
-    this.inputLoad.addEventListener('change', () => { this.load(this.inputLoad.files, this.loadMap); });
-    this.inputImport.addEventListener('change', () => { this.load(this.inputImport.files, this.importMap); });
+    this.inputLoad.addEventListener('change', this.handleInputLoad);
+    this.inputImport.addEventListener('change', this.handleInputImport);
+  }
+
+  private handleInputLoad = () => {
+    this.load(this.inputLoad.files, this.loadMap);
+    this.inputLoad.value = null;
+  }
+
+  private handleInputImport = () => {
+    this.load(this.inputImport.files, this.importMap);
+    this.inputImport.value = null;
   }
 
   private createMenuItem(selector: string, f?: any) {


### PR DESCRIPTION
Inside Chrome or a derivative of it (like Electron), when attempting to load/import the same map more than once the import fails silently (on Windows) or the map file is not even selectable (on Mac OS).

The solution is to set the value of the associated ``HTMLInputElement`` to ``null`` after loading/importing a map.

Resolves #19, #27 