### PR TITLE
On macOS, use Cmd instead of Ctrl for keyboard shortcuts

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -91,6 +91,12 @@ export class Editor implements Subscriber {
     this.ctrlZoom.addEventListener('change', () => { this.cmdZoom(); });
     this.updateZoomPercentage();
     App.mainHTMLCanvas.addEventListener('keyup', (e: KeyboardEvent) => { this.keyUp(e); });
+    document.body.addEventListener('copy', (e: KeyboardEvent) => {
+      this.cmdCopySelection();
+    });
+    document.body.addEventListener('paste', (e: ClipboardEvent) => {
+      this.cmdPaste();
+    });
 
     this.resize();
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -97,6 +97,12 @@ export class Editor implements Subscriber {
     document.body.addEventListener('paste', (e: ClipboardEvent) => {
       this.cmdPaste();
     });
+    App.mainHTMLCanvas.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.metaKey) switch(e.key) {
+        case 'a': this.cmdSelectAll(); break;
+        case 'z': App.undo(); break;
+      }
+    });
 
     this.resize();
 


### PR DESCRIPTION
Fixes #53.

Supported:

* ⌘A
* ⌘C
* ⌘V
* ⌘Z