### PR TITLE
Allow Enter key in room name to dismiss room panel.

### DIFF
--- a/src/panels/roomPanel/RoomPanel.ts
+++ b/src/panels/roomPanel/RoomPanel.ts
@@ -4,6 +4,7 @@ import { Room, Obj } from '../../models';
 import { Panel }  from '../'
 import { IdColorPicker, IdInput, IdRange, IdCheck, IdTextarea, IdPopup, IdShape, IdLineStyle, IdToast } from '../../controls';
 import { IdObjectEditor } from '../../controls/idObjectEditor/idObjectEditor';
+import { App } from "../../App";
 
 export class RoomPanel extends Panel implements Subscriber {
   private room: Room;
@@ -30,6 +31,12 @@ export class RoomPanel extends Panel implements Subscriber {
     Dispatcher.subscribe(this);
 
     this.ctrlName = new IdInput('.js-name', this.elem).addEventListener('input', () => { this.room.name = this.ctrlName.value; });
+    this.ctrlName.addEventListener('keyup', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        this.close();
+        App.mainHTMLCanvas.focus();
+      }
+    });
     this.ctrlSubtitle = new IdInput('.js-subtitle', this.elem).addEventListener('input', () => { this.room.subtitle = this.ctrlSubtitle.value; });
     this.ctrlDark = new IdCheck('.js-dark', this.elem).addEventListener('input', () => { this.room.dark = this.ctrlDark.checked; })
     this.ctrlStartroom = new IdCheck('.js-startroom', this.elem).addEventListener('input', () => { this.room.setStartRoom(this.ctrlStartroom.checked); })


### PR DESCRIPTION
While using the keyboard to build out a map, I found that I was constantly reaching up to the Escape key to dismiss the room panel. With this change, I can use shift-arrows to create and navigate to rooms, then Enter to open the room panel, type a room name, and Enter to dismiss the room panel, which feels way better as a keyboard experience.