### PR TITLE
Support devicePixelRatio

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -19,6 +19,7 @@ export class App {
   static zoom: number = 1;
   static centerX: number = 0;
   static centerY: number = 0;
+  static devicePixelRatio: number = window.devicePixelRatio;
   static mouseMode: MouseMode = MouseMode.None;
   static undoStack: Array<string> = new Array<string>();
   static selection: Selection; 

--- a/src/Editor.ts
+++ b/src/Editor.ts
@@ -44,14 +44,14 @@ export class Editor implements Subscriber {
     Dispatcher.subscribe(this);
 
     // Access the main canvas:
-    this.mainCanvas = new Canvas(App.mainHTMLCanvas.getContext('2d'));
+    this.mainCanvas = new Canvas(App.mainHTMLCanvas);
 
     // Access the background canvas:
-    this.bgCanvas = new Canvas(App.bgHTMLCanvas.getContext('2d'));
+    this.bgCanvas = new Canvas(App.bgHTMLCanvas);
 
     // Access the 1x1 hittest canvas:
     this.hitTestHtmlCanvas = <HTMLCanvasElement> document.getElementById('hittest');
-    this.hitTestCanvas = new Canvas(this.hitTestHtmlCanvas.getContext('2d'));
+    this.hitTestCanvas = new Canvas(this.hitTestHtmlCanvas);
 
     this.views = new Array();
 
@@ -489,10 +489,12 @@ export class Editor implements Subscriber {
   // 
   findMouseCoordinates(e: MouseEvent) {
     let { x, y } = this.findObjCoordinates(App.mainHTMLCanvas);
-    return { 
-      x: Math.floor((e.clientX - x - App.mainHTMLCanvas.offsetWidth / 2 - App.centerX) / App.zoom), 
-      y: Math.floor((e.clientY - y - App.mainHTMLCanvas.offsetHeight / 2 - App.centerY) / App.zoom)
+    const dpr = App.devicePixelRatio;
+    const result = {
+      x: Math.floor((e.clientX - x - App.mainHTMLCanvas.offsetWidth / 2 / dpr - App.centerX / dpr) / App.zoom),
+      y: Math.floor((e.clientY - y - App.mainHTMLCanvas.offsetHeight / 2 / dpr - App.centerY / dpr) / App.zoom)
     };
+    return result;
   }
 
   findViewByCoordinates(x: number, y: number) {
@@ -713,8 +715,8 @@ export class Editor implements Subscriber {
     // We do different things for different mouse modes.
     switch(App.mouseMode) {
       case MouseMode.Scroll:
-        App.centerX = this.scrollOriginX + (e.clientX - this.scrollOffsetX);
-        App.centerY = this.scrollOriginY + (e.clientY - this.scrollOffsetY);
+        App.centerX = this.scrollOriginX + (e.clientX - this.scrollOffsetX) * App.devicePixelRatio;
+        App.centerY = this.scrollOriginY + (e.clientY - this.scrollOffsetY) * App.devicePixelRatio;
         this.refresh(true);
         break; 
 
@@ -936,8 +938,8 @@ export class Editor implements Subscriber {
   // 
   // Move the canvas center by (dx, dy)
   moveCenter(dx: number, dy: number) {
-    App.centerX += dx * App.map.settings.grid.size;
-    App.centerY += dy * App.map.settings.grid.size;
+    App.centerX += (dx * App.map.settings.grid.size * App.devicePixelRatio);
+    App.centerY += (dy * App.map.settings.grid.size * App.devicePixelRatio);
     this.refresh(true);
   }
 

--- a/src/Exporter.ts
+++ b/src/Exporter.ts
@@ -9,7 +9,6 @@ export class Exporter {
   private map: Map;
   private canvasElem: HTMLCanvasElement;
   private canvas: Canvas;
-  private ctx: CanvasRenderingContext2D;
   private views: View[];
   private left: number;
   private top: number;
@@ -19,8 +18,7 @@ export class Exporter {
   public constructor(map: Map) {
     this.map = map;
     this.canvasElem = <HTMLCanvasElement> document.getElementById('export');
-    this.ctx = this.canvasElem.getContext('2d')
-    this.canvas = new Canvas(this.ctx);
+    this.canvas = new Canvas(this.canvasElem);
 
     // Assume a canvas of 100x100.
     // This will avoid problems in case of an empty map.
@@ -39,6 +37,7 @@ export class Exporter {
     this.canvasElem.height = this.height;
 
     this.canvas.save();
+    this.canvas.scale(1);
 
     if(withBackground) {
       this.canvas
@@ -79,7 +78,7 @@ export class Exporter {
   // If there is no whitespace at the top, return true.
   // 
   private hasPixelsTop() {
-    var myImageData = this.ctx.getImageData(0, 0, this.width, 1);
+    var myImageData = this.canvas.getImageData(0, 0, this.width, 1);
     for(let i = 0; i < this.width; i++) {
       if(myImageData.data[i * 4 + 3] > 0) return true;
     }
@@ -90,7 +89,7 @@ export class Exporter {
   // If there is no whitespace at the bottom, return true.
   //   
   private hasPixelsBottom() {
-    var myImageData = this.ctx.getImageData(0, this.height - 1, this.width, 1);
+    var myImageData = this.canvas.getImageData(0, this.height - 1, this.width, 1);
     for(let i = 0; i < this.width; i++) {
       if(myImageData.data[i * 4 + 3] > 0) return true;
     }
@@ -101,7 +100,7 @@ export class Exporter {
   // If there is no whitespace on the left, return true.
   //   
   private hasPixelsLeft() {
-    var myImageData = this.ctx.getImageData(0, 0, 1, this.height);
+    var myImageData = this.canvas.getImageData(0, 0, 1, this.height);
     for(let i = 0; i < this.height; i++) {
       if(myImageData.data[i * 4 + 3] > 0) return true;
     }
@@ -112,7 +111,7 @@ export class Exporter {
   // If there is no whitespace on the right, return true.
   //   
   private hasPixelsRight() {
-    var myImageData = this.ctx.getImageData(this.width - 1, 0, 1, this.height);
+    var myImageData = this.canvas.getImageData(this.width - 1, 0, 1, this.height);
     for(let i = 0; i < this.height; i++) {
       if(myImageData.data[i * 4 + 3] > 0) return true;
     }

--- a/src/Grid.ts
+++ b/src/Grid.ts
@@ -32,18 +32,19 @@ export class Grid {
     let settings = App.map.settings.grid;
     if(!settings.visible) return;
 
+    const dpr = App.devicePixelRatio;
     canvas
       .save()
       .strokeStyle(settings.color)
-      .lineWidth(settings.lineWidth);
+      .lineWidth(settings.lineWidth * dpr);
     var x = htmlCanvas.offsetWidth / 2 + App.centerX;
-    while(x > 0) { this.drawGridLineV(htmlCanvas, canvas, x); x -= settings.size * App.zoom; }
-    var x = htmlCanvas.offsetWidth / 2 + App.centerX + settings.size * App.zoom;
-    while(x < htmlCanvas.offsetWidth) { this.drawGridLineV(htmlCanvas, canvas, x); x += settings.size * App.zoom; }
+    while(x > 0) { this.drawGridLineV(htmlCanvas, canvas, x); x -= settings.size * App.zoom * dpr; }
+    var x = htmlCanvas.offsetWidth / 2 + App.centerX + settings.size * App.zoom * dpr;
+    while(x < htmlCanvas.offsetWidth) { this.drawGridLineV(htmlCanvas, canvas, x); x += settings.size * App.zoom * dpr; }
     var y = htmlCanvas.offsetHeight / 2 + App.centerY;
-    while(y > 0) { this.drawGridLineH(htmlCanvas,canvas, y); y -=  settings.size * App.zoom; }
-    var y = htmlCanvas.offsetHeight / 2 + App.centerY + settings.size * App.zoom;
-    while(y < htmlCanvas.offsetHeight) { this.drawGridLineH(htmlCanvas, canvas, y); y += settings.size * App.zoom; }
+    while(y > 0) { this.drawGridLineH(htmlCanvas,canvas, y); y -=  settings.size * App.zoom * dpr; }
+    var y = htmlCanvas.offsetHeight / 2 + App.centerY + settings.size * App.zoom * dpr;
+    while(y < htmlCanvas.offsetHeight) { this.drawGridLineH(htmlCanvas, canvas, y); y += settings.size * App.zoom * dpr; }
 
     // Draw origin if necessary
     if(settings.origin) {
@@ -51,11 +52,11 @@ export class Grid {
       y = Math.floor(htmlCanvas.offsetHeight / 2) + App.centerY;
       canvas
         .beginPath()
-        .lineWidth(settings.originWidth)
-        .moveTo(x, y - settings.size * App.zoom)
-        .lineTo(x, y + settings.size * App.zoom)
-        .moveTo(x - settings.size * App.zoom, y)
-        .lineTo(x + settings.size * App.zoom, y)
+        .lineWidth(settings.originWidth * dpr)
+        .moveTo(x, y - settings.size * App.zoom * dpr)
+        .lineTo(x, y + settings.size * App.zoom * dpr)
+        .moveTo(x - settings.size * App.zoom * dpr, y)
+        .lineTo(x + settings.size * App.zoom * dpr, y)
         .stroke();
     }
 

--- a/src/drawing/canvas.ts
+++ b/src/drawing/canvas.ts
@@ -6,11 +6,18 @@ import { DrawContext } from './drawContext'
 export class Canvas implements IScreen {
 
   private drawer: DrawContext;
+  private ctx: CanvasRenderingContext2D;
   
   constructor(
-    private ctx: CanvasRenderingContext2D
+    private canvas: HTMLCanvasElement
   ) {
-    this.ctx = ctx;
+    this.ctx = canvas.getContext('2d');
+    if (App.devicePixelRatio !== 1) {
+      canvas.style.transform = `scale(calc(1/${App.devicePixelRatio}))`;
+      canvas.style.transformOrigin = "left top";
+      canvas.style.width = (100*App.devicePixelRatio) + '%';
+      canvas.style.height = (100*App.devicePixelRatio) + '%';
+    }
     this.drawer = new DrawContext(this.ctx);
   }
 
@@ -36,7 +43,7 @@ export class Canvas implements IScreen {
 
   scale(x: number, y?: number): IScreen {
     if(y === undefined) y = x;
-    this.ctx.scale(x, y);
+    this.ctx.scale(x * App.devicePixelRatio, y * App.devicePixelRatio);
     return this;
   }
 

--- a/src/popups/Popup.ts
+++ b/src/popups/Popup.ts
@@ -11,8 +11,9 @@ export class Popup {
   }
 
   protected showAt(x: number, y: number) {
-    this.elem.style.left = App.mainHTMLCanvas.offsetWidth / 2 + App.centerX + x * App.zoom + "px"; 
-    this.elem.style.top = App.mainHTMLCanvas.offsetHeight / 2 + App.centerY + y * App.zoom - 32 + "px";
+    const dpr = App.devicePixelRatio;
+    this.elem.style.left = App.mainHTMLCanvas.offsetWidth / 2 / dpr + App.centerX / dpr + x * App.zoom + "px";
+    this.elem.style.top = App.mainHTMLCanvas.offsetHeight / 2 / dpr + App.centerY / dpr + y * App.zoom - 32 + "px";
     this.elem.style.display = 'flex';
     // Close any open overlays inside popup.
     let overlays = this.elem.querySelectorAll(".popup-overlay");


### PR DESCRIPTION
Fixes #80.

This looks way better on my 16" MacBook Pro. But! It was extremely difficult code to write and work with. Pretty much all of these `* dpr` and `/ dpr`s were discovered through painful trial and error. It wouldn't surprise me at all if I've introduced some subtle bugs, and it seems especially likely that this PR will make the code less maintainable over time.

If your screen doesn't support HiDPI mode, you can manually set `App.devicePixelRatio` to 2 to get a sense of what it would look like.

* The core approach to devicePixelRatio is to render a larger canvas, but use CSS to resize the canvas down to a smaller than natural size. https://www.html5rocks.com/en/tutorials/canvas/hidpi/ This article describes a common technique, but it doesn't work here, because there's code setting `canvas.width` and `.height` based on the CSS width/height `100%`. So instead of the normal documented technique, in `canvas.ts` we're setting the scale to be `* dpr` and configuring a CSS `width: calc(dpr * 100%)` and `transform: scale(calc(1/dpr))`
* `App.centerX` and `.centerY` are now proportionally larger, so we have to `/ dpr` in `findMouseCoordinates`, and `* dpr` in places where we're setting `centerX`.

![image](https://user-images.githubusercontent.com/96150/81491459-a8c26e00-9243-11ea-8bc2-33f497c1b930.png)
